### PR TITLE
Added option to run silently. Uses existing config.

### DIFF
--- a/app/screenbloom.py
+++ b/app/screenbloom.py
@@ -436,7 +436,7 @@ def dll_error_page():
                            fonts_path=fonts_path)
 
 
-def start_tornando():
+def start_tornado():
         # Tornado
         http_server = HTTPServer(WSGIContainer(app))
         http_server.listen(5000)
@@ -465,5 +465,5 @@ if __name__ == '__main__':
         launch_browser()
 
     #Initialize and run our server
-    start_tornando()
+    start_tornado()
    

--- a/app/screenbloom.py
+++ b/app/screenbloom.py
@@ -5,8 +5,10 @@ import modules.vendor.rgb_cie as rgb_cie
 from tornado.wsgi import WSGIContainer
 from tornado.ioloop import IOLoop
 from config import params
+import argparse
 import socket
 import json
+import sys
 import os
 
 app = Flask(__name__)
@@ -434,15 +436,34 @@ def dll_error_page():
                            fonts_path=fonts_path)
 
 
-if __name__ == '__main__':
-    local_host = socket.gethostbyname(socket.gethostname())
-    startup_thread = startup.StartupThread(local_host)
-    startup_thread.start()
+def start_tornando():
+        # Tornado
+        http_server = HTTPServer(WSGIContainer(app))
+        http_server.listen(5000)
+        IOLoop.instance().start()
+        
+def launch_browser():
+        local_host = socket.gethostbyname(socket.gethostname())
+        startup_thread = startup.StartupThread(local_host)
+        startup_thread.start()
 
+if __name__ == '__main__':
+    #Check arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-q", "--silent", help="autostart without launching a browser. Uses existing config.",
+                    action="store_true")
+    args = parser.parse_args()
+    
     # Flask default server
     # app.run(debug=False, host=local_host, use_reloader=False)
+        
+    #Check if we want to run silently (i.e. don't launch a browser)
+    if args.silent:
+        print "Silent Mode selected"
+    else:
+        print "Default launch mode selected"
+        launch_browser()
 
-    # Tornado
-    http_server = HTTPServer(WSGIContainer(app))
-    http_server.listen(5000)
-    IOLoop.instance().start()
+    #Initialize and run our server
+    start_tornando()
+   


### PR DESCRIPTION
I'm not able to fully test it since I'm currently out of town but it appears to run on my test environment. Please let me know if there are any changes I need to make.

This should allow users to optionally configure Screen Bloom to start silently without opening a web browser. This is useful for those who want it to be a set-it-and-forget-it type application. 

To run silently simply do the following:
`python screenbloom.py -q`

For a compiled executable:
`screenbloom.exe -q`